### PR TITLE
Remover valor mínimo de compra para cupom

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,13 @@ Projeto Pessoal/
 - Desbloqueados automaticamente após atingir número de compras
 - Configurados pelas empresas
 - Validade personalizada
-- Valor mínimo configurável
 
 ### Cupons Empresariais
 - Criados pelas empresas através do portal
 - Desconto personalizado (1% a 100%)
 - Validade em dias (1 a 365)
 - Compras necessárias configuráveis
-- Descrição e valor mínimo opcionais
+- Descrição opcional
 
 ## 🔐 Segurança
 

--- a/css/home.css
+++ b/css/home.css
@@ -598,15 +598,7 @@ body {
   font-style: italic;
 }
 
-.cupom-valor-minimo {
-  font-size: 0.8rem;
-  margin-bottom: 8px;
-  opacity: 0.8;
-  background: rgba(255, 255, 255, 0.2);
-  padding: 4px 8px;
-  border-radius: 4px;
-  display: inline-block;
-}
+
 
 /* Cupons List */
 .cupons-list {

--- a/empresa-dashboard.html
+++ b/empresa-dashboard.html
@@ -337,10 +337,6 @@
             <label for="descricao">Descrição do Cupom</label>
             <input type="text" id="descricao" placeholder="Ex: Desconto especial para clientes fiéis" maxlength="100">
           </div>
-          <div class="form-group">
-            <label for="valorMinimo">Valor Mínimo da Compra</label>
-            <input type="number" id="valorMinimo" placeholder="Ex: 50.00" min="0" step="0.01">
-          </div>
         </div>
         <div class="form-actions">
           <button type="button" onclick="limparFormulario()" class="btn-secondary">
@@ -401,10 +397,6 @@
           <div class="form-group">
             <label for="editDescricao">Descrição</label>
             <input type="text" id="editDescricao" maxlength="100">
-          </div>
-          <div class="form-group">
-            <label for="editValorMinimo">Valor Mínimo</label>
-            <input type="number" id="editValorMinimo" min="0" step="0.01">
           </div>
         </div>
         <div class="form-actions">

--- a/js/empresa-dashboard.js
+++ b/js/empresa-dashboard.js
@@ -83,7 +83,6 @@ function carregarCuponsEmpresa() {
                     <p><strong>Validade:</strong> ${cupom.validade} dias</p>
                     <p><strong>Compras necessárias:</strong> ${cupom.comprasNecessarias}</p>
                     ${cupom.descricao ? `<p><strong>Descrição:</strong> ${cupom.descricao}</p>` : ''}
-                    ${cupom.valorMinimo ? `<p><strong>Valor mínimo:</strong> R$ ${cupom.valorMinimo.toFixed(2)}</p>` : ''}
                     <p><strong>Criado em:</strong> ${formatarData(cupom.dataCriacao)}</p>
                 </div>
             </div>
@@ -121,7 +120,6 @@ function criarCupom() {
     const validade = parseInt(document.getElementById('validade').value);
     const comprasNecessarias = parseInt(document.getElementById('comprasNecessariasCupom').value);
     const descricao = document.getElementById('descricao').value.trim();
-    const valorMinimo = parseFloat(document.getElementById('valorMinimo').value) || 0;
     
     if (!desconto || !validade || !comprasNecessarias) {
         mostrarMensagem('Por favor, preencha todos os campos obrigatórios.', 'error');
@@ -139,7 +137,6 @@ function criarCupom() {
         validade: validade,
         comprasNecessarias: comprasNecessarias,
         descricao: descricao,
-        valorMinimo: valorMinimo,
         dataCriacao: new Date().toISOString(),
         empresaId: empresaLogada.id
     };
@@ -201,7 +198,6 @@ function editarCupom(cupomId) {
     document.getElementById('editValidade').value = cupom.validade;
     document.getElementById('editComprasNecessarias').value = cupom.comprasNecessarias;
     document.getElementById('editDescricao').value = cupom.descricao || '';
-    document.getElementById('editValorMinimo').value = cupom.valorMinimo || '';
     
     // Mostrar modal
     document.getElementById('editModal').style.display = 'flex';
@@ -214,7 +210,6 @@ function salvarEdicaoCupom() {
     const validade = parseInt(document.getElementById('editValidade').value);
     const comprasNecessarias = parseInt(document.getElementById('editComprasNecessarias').value);
     const descricao = document.getElementById('editDescricao').value.trim();
-    const valorMinimo = parseFloat(document.getElementById('editValorMinimo').value) || 0;
     
     if (!desconto || !validade || !comprasNecessarias) {
         mostrarMensagem('Por favor, preencha todos os campos obrigatórios.', 'error');
@@ -235,7 +230,6 @@ function salvarEdicaoCupom() {
                 validade: validade,
                 comprasNecessarias: comprasNecessarias,
                 descricao: descricao,
-                valorMinimo: valorMinimo,
                 dataAtualizacao: new Date().toISOString()
             };
             

--- a/js/home.js
+++ b/js/home.js
@@ -387,9 +387,7 @@ class FidelixSystem {
             if (cupom.descricao) {
                 cupomInfo += `<div class="cupom-descricao">${cupom.descricao}</div>`;
             }
-            if (cupom.valorMinimo && cupom.valorMinimo > 0) {
-                cupomInfo += `<div class="cupom-valor-minimo">Mínimo: R$ ${cupom.valorMinimo.toFixed(2)}</div>`;
-            }
+
             
             return `
                 <div class="cupom-card ${empresa ? 'empresa-cupom' : ''}" onclick="fidelixSystem.usarCupom(${cupom.id})">
@@ -1077,7 +1075,7 @@ class FidelixSystem {
                             utilizado: false,
                             comprasNecessarias: cupomEmpresa.comprasNecessarias,
                             descricao: cupomEmpresa.descricao,
-                            valorMinimo: cupomEmpresa.valorMinimo
+
                         };
 
                         this.cupons.push(novoCupom);


### PR DESCRIPTION
Remove the minimum purchase value field from coupon creation and editing in the business area.

This change allows companies to create coupons without needing to specify a minimum purchase value, simplifying the process and making coupons more flexible.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0e1cf0d-256c-43c3-bf03-e8ab41537f4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0e1cf0d-256c-43c3-bf03-e8ab41537f4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

