### PR TITLE
Corrigir recompensa de cupom duplicada

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -1057,16 +1057,17 @@ class FidelixSystem {
         
         if (empresa && empresa.cupons) {
             empresa.cupons.forEach(cupomEmpresa => {
-                if (comprasLoja >= cupomEmpresa.comprasNecessarias) {
-                    // Verificar se já existe um cupom não utilizado
-                    const cupomExistente = this.cupons.find(c => 
+                // Concede o cupom somente no exato momento em que a meta é atingida
+                if (comprasLoja === cupomEmpresa.comprasNecessarias) {
+                    // Evitar duplicatas (mesmo se o usuário já tiver utilizado um anterior)
+                    const jaGerado = this.cupons.some(c => 
                         c.lojaId === lojaId && 
                         c.desconto === cupomEmpresa.desconto && 
-                        !c.utilizado &&
+                        c.comprasNecessarias === cupomEmpresa.comprasNecessarias &&
                         c.empresaId === empresa.id
                     );
 
-                    if (!cupomExistente) {
+                    if (!jaGerado) {
                         const novoCupom = {
                             id: Date.now(),
                             lojaId: lojaId,
@@ -1091,16 +1092,17 @@ class FidelixSystem {
         // Verificar cupons padrão da loja (mantendo compatibilidade)
         if (loja.cupons) {
             loja.cupons.forEach(cupomConfig => {
-                if (comprasLoja >= cupomConfig.comprasNecessarias) {
-                    // Verificar se já existe um cupom não utilizado
-                    const cupomExistente = this.cupons.find(c => 
+                // Concede o cupom somente quando atingir exatamente a meta
+                if (comprasLoja === cupomConfig.comprasNecessarias) {
+                    // Evitar duplicatas considerando a meta atingida
+                    const jaGerado = this.cupons.some(c => 
                         c.lojaId === lojaId && 
                         c.desconto === cupomConfig.desconto && 
-                        !c.utilizado &&
+                        c.comprasNecessarias === cupomConfig.comprasNecessarias &&
                         !c.empresaId // Cupons padrão não têm empresaId
                     );
 
-                    if (!cupomExistente) {
+                    if (!jaGerado) {
                         const novoCupom = {
                             id: Date.now(),
                             lojaId: lojaId,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes repeated coupon generation after reaching a purchase goal.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous logic granted a coupon for every purchase once `comprasLoja` exceeded `comprasNecessarias`. This change ensures a coupon is only granted when `comprasLoja` exactly matches `comprasNecessarias` and improves the duplicate check to prevent re-issuing the same coupon for the same goal.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9706595-ffbd-4543-8dff-7f89dbab089a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9706595-ffbd-4543-8dff-7f89dbab089a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

