### PR TITLE
Fix store filter in purchase history

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -346,6 +346,7 @@ class FidelixSystem {
         this.carregarUltimasCompras();
         this.carregarCuponsDisponiveis();
         this.carregarCuponsUtilizados();
+        this.popularFiltroLojas();
         this.carregarHistoricoCompras();
         this.carregarHistoricoCupons();
         this.carregarProgressoLojas();
@@ -658,6 +659,22 @@ class FidelixSystem {
                 </div>
             `;
         }).join('');
+    }
+
+    // Popular opções do filtro de lojas
+    popularFiltroLojas() {
+        const selectLojas = document.getElementById('filtroLoja');
+        if (!selectLojas) return;
+
+        const valorSelecionado = selectLojas.value;
+        const opcoes = ['<option value="">Todas as Lojas</option>']
+            .concat(this.lojas.map(loja => `<option value="${loja.id}">${loja.nome}</option>`))
+            .join('');
+        selectLojas.innerHTML = opcoes;
+
+        if (valorSelecionado && Array.from(selectLojas.options).some(o => o.value === valorSelecionado)) {
+            selectLojas.value = valorSelecionado;
+        }
     }
 
     // Filtrar histórico


### PR DESCRIPTION
Populate the store filter dropdown in the purchase history to allow store selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0ecb712-80c3-4ad9-a33b-88900129b66a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0ecb712-80c3-4ad9-a33b-88900129b66a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

